### PR TITLE
Use an alias to avoid having to use backtracking relative paths

### DIFF
--- a/web_external/redux/action/index.js
+++ b/web_external/redux/action/index.js
@@ -1,4 +1,4 @@
-import { makeEnum } from '../../util';
+import { makeEnum } from '~reslab/util';
 import actionSpec from './actionspec.yml';
 
 const buildActionConstructor = (type, argSpec) => {

--- a/web_external/redux/reducer/index.js
+++ b/web_external/redux/reducer/index.js
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
-import { makeEnum } from '../../util';
-import { actionType } from '../action';
+import { makeEnum } from '~reslab/util';
+import { actionType } from '~reslab/redux/action';
 
 const appMode = makeEnum('appMode', [
   'startScreen',

--- a/web_external/redux/store/index.js
+++ b/web_external/redux/store/index.js
@@ -1,6 +1,6 @@
 import { createStore } from 'redux';
 
-import { reducer } from '../reducer';
+import { reducer } from '~reslab/redux/reducer';
 
 const store = createStore(reducer);
 

--- a/web_external/view/layout/header/index.jade
+++ b/web_external/view/layout/header/index.jade
@@ -3,7 +3,7 @@
 
 #interfaceIcons
   img#helpButton.headerButton(title="Show information about the interface" src=infoIcon)
-  //- img#achievementsButton.headerButton(src="../../../images/achievements.svg")
+  //- img#achievementsButton.headerButton(src="~reslab/images/achievements.svg")
   img#hamburgerButton.headerButton(title="Main Menu" src=hamburgerIcon)
 
 #projectHeader

--- a/web_external/view/layout/header/index.js
+++ b/web_external/view/layout/header/index.js
@@ -1,16 +1,16 @@
 import { event,
          select } from 'd3-selection';
 
-import { action } from '../../../redux/action';
-import { appMode } from '../../../redux/reducer';
-import { store } from '../../../redux/store';
+import { action } from '~reslab/redux/action';
+import { appMode } from '~reslab/redux/reducer';
+import { store } from '~reslab/redux/store';
 
 import './index.styl';
 import html from './index.jade';
 import hamburgerIcon from './hamburger.svg';
 import infoIcon from './info.svg';
 import publicIcon from './public.svg';
-import reslabIcon from '../../../image/Resonant_Lab_cropped.svg';
+import reslabIcon from '~reslab/image/Resonant_Lab_cropped.svg';
 
 const initialize = (sel) => {
   sel.html(html({

--- a/web_external/view/overlay/LoginDialog/index.js
+++ b/web_external/view/overlay/LoginDialog/index.js
@@ -1,8 +1,8 @@
 import html from './index.jade';
 import './index.styl';
 
-import { action } from '../../../redux/action';
-import { store } from '../../../redux/store';
+import { action } from '~reslab/redux/action';
+import { store } from '~reslab/redux/store';
 
 import { login } from 'girder/auth';
 

--- a/web_external/view/overlay/StartingScreen/index.js
+++ b/web_external/view/overlay/StartingScreen/index.js
@@ -3,22 +3,22 @@ import { select } from 'd3-selection';
 import html from './index.jade';
 import './index.styl';
 
-import folderIcon from '../../../image/light/folder.svg';
-import fileIcon from '../../../image/light/file.svg';
-import scatterplotIcon from '../../../image/light/scatterplot.svg';
-import datasetIcon from '../../../image/light/dataset.svg';
-import reslabBanner from '../../../image/Resonant_Lab_cropped.svg';
-import reslabLogo from '../../../image/Resonant_Lab_Mark.svg';
-import resonantLogo from '../../../image/Resonant_Mark.svg';
-import kitwareLogo from '../../../image/Kitware_Mark.svg';
-import githubLogo from '../../../image/Github_Mark.svg';
-import contactIcon from '../../../image/contact.svg';
-import closeIcon from '../../../image/close.svg';
+import folderIcon from '~reslab/image/light/folder.svg';
+import fileIcon from '~reslab/image/light/file.svg';
+import scatterplotIcon from '~reslab/image/light/scatterplot.svg';
+import datasetIcon from '~reslab/image/light/dataset.svg';
+import reslabBanner from '~reslab/image/Resonant_Lab_cropped.svg';
+import reslabLogo from '~reslab/image/Resonant_Lab_Mark.svg';
+import resonantLogo from '~reslab/image/Resonant_Mark.svg';
+import kitwareLogo from '~reslab/image/Kitware_Mark.svg';
+import githubLogo from '~reslab/image/Github_Mark.svg';
+import contactIcon from '~reslab/image/contact.svg';
+import closeIcon from '~reslab/image/close.svg';
 
-import { action } from '../../../redux/action';
-import { store } from '../../../redux/store';
-import { appMode } from '../../../redux/reducer';
-import { initializeNewProject } from '../../../util';
+import { action } from '~reslab/redux/action';
+import { store } from '~reslab/redux/store';
+import { appMode } from '~reslab/redux/reducer';
+import { initializeNewProject } from '~reslab/util';
 
 import { logout } from 'girder/auth';
 

--- a/webpack.helper.js
+++ b/webpack.helper.js
@@ -83,6 +83,10 @@ module.exports = function (config, data) {
     }
   ].concat(config.module.loaders);
 
+  config.resolve = config.resolve || {};
+  config.resolve.alias = config.resolve.alias || {};
+  config.resolve.alias['~reslab'] = pluginSourceDir;
+
   generateColorTable(pluginSourceDir);
 
   return candelaWebpack(config, path.resolve(pluginSourceDir, '..', 'node_modules', 'candela'));


### PR DESCRIPTION
Basically, this allows us to write `import foobar from ~reslab/absolute/path/to/foobar` instead of `import foobar from ../../../../absolute/path/to/foobar`, etc. We should still use relative paths for assets that are bundled with the file in question, e.g. Jade templates for a component, etc.